### PR TITLE
Use browser safe APIs, some minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ msbuild.binlog
 .DS_Store
 
 .fake
+.idea

--- a/sizoscopeX/MainView.axaml
+++ b/sizoscopeX/MainView.axaml
@@ -37,14 +37,14 @@
 					</Button>
 				</Border>
 			</Grid>
-			<TreeView ItemsSource="{Binding Items}" DoubleTapped="Tree_DoubleTapped" Grid.Row="1" IsVisible="{Binding File, Converter={x:Static ObjectConverters.IsNotNull},Mode=OneWay}">
+			<TreeView ItemsSource="{Binding Items}" DoubleTapped="Tree_DoubleTapped" Grid.Row="1" IsVisible="{Binding CurrentData, Converter={x:Static ObjectConverters.IsNotNull},Mode=OneWay}">
 				<TreeView.ItemTemplate>
 					<TreeDataTemplate ItemsSource="{Binding Nodes}">
 						<controls:TreeItemControl Type="{Binding Type}" Text="{Binding Name}" />
 					</TreeDataTemplate>
 				</TreeView.ItemTemplate>
 			</TreeView>
-			<Grid Grid.Row="1" IsVisible="{Binding File, Converter={x:Static ObjectConverters.IsNull},Mode=OneWay}">
+			<Grid Grid.Row="1" IsVisible="{Binding CurrentData, Converter={x:Static ObjectConverters.IsNull},Mode=OneWay}">
 				<StackPanel Margin="0,-40,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
 					<TextBlock FontSize="24" Text="Welcome" HorizontalAlignment="Center" />
 					<Button Margin="0,8,0,0" Content="Open a file to continue..." Click="Open_Clicked" HorizontalAlignment="Center" />

--- a/sizoscopeX/MainView.axaml.cs
+++ b/sizoscopeX/MainView.axaml.cs
@@ -38,13 +38,10 @@ public partial class MainView : UserControl
             e.DragEffects &= DragDropEffects.Copy;
             if (e.Data.Contains(DataFormats.Files))
             {
-                var mstat = e.Data.GetFiles()?.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 'm' or 'M', 's' or 'S', 't' or 'T', 'a' or 'A', 't' or 'T'] }) as IStorageFile;
-                var dmgl = e.Data.GetFiles()?.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 's' or 'S', 'c' or 'C', 'a' or 'A', 'n' or 'N', '.', 'd' or 'D', 'g' or 'G', 'm' or 'M', 'l' or 'L', '.', 'x' or 'X', 'm' or 'M', 'l' or 'L'] }) as IStorageFile;
-                if (mstat is null)
-                {
-                    throw new InvalidOperationException("An invalid file has been dropped.");
-                }
-                viewModel.File = (await mstat.OpenReadAsync(), dmgl is null ? null : await dmgl.OpenReadAsync());
+                var files = e.Data.GetFiles()!.ToArray();
+                
+                var (mstatStream, dmglStream) = await ReadStatFilesAsync(files);
+                viewModel.File = (mstatStream, dmglStream);
             }
         }
         catch (Exception ex)
@@ -71,20 +68,9 @@ public partial class MainView : UserControl
             });
             if (result.Any())
             {
-                var mstat = result.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 'm' or 'M', 's' or 'S', 't' or 'T', 'a' or 'A', 't' or 'T'] });
-                var dmgl = result.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 's' or 'S', 'c' or 'C', 'a' or 'A', 'n' or 'N', '.', 'd' or 'D', 'g' or 'G', 'm' or 'M', 'l' or 'L', '.', 'x' or 'X', 'm' or 'M', 'l' or 'L'] });
-                if (mstat is null)
-                {
-                    throw new InvalidOperationException("An invalid file has been dropped.");
-                }
-                if (dmgl is null)
-                {
-                    if (mstat.TryGetLocalPath() is string path)
-                    {
-                        dmgl = await StorageProvider.TryGetFileFromPathAsync(Path.ChangeExtension(path, "scan.dgml.xml"));
-                    }
-                }
-                viewModel.File = (await mstat.OpenReadAsync(), dmgl is null ? null : await dmgl.OpenReadAsync());
+                var (mstatStream, dmglStream) = await ReadStatFilesAsync(result);
+
+                viewModel.File = (mstatStream, dmglStream);
             }
         }
         catch (Exception ex)
@@ -129,27 +115,10 @@ public partial class MainView : UserControl
             });
             if (result.Any())
             {
-                var mstat = result.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 'm' or 'M', 's' or 'S', 't' or 'T', 'a' or 'A', 't' or 'T'] });
-                var dmgl = result.FirstOrDefault(i => i is IStorageFile { Name: [.., '.', 's' or 'S', 'c' or 'C', 'a' or 'A', 'n' or 'N', '.', 'd' or 'D', 'g' or 'G', 'm' or 'M', 'l' or 'L', '.', 'x' or 'X', 'm' or 'M', 'l' or 'L'] });
-                if (mstat is null)
-                {
-                    throw new InvalidOperationException("An invalid file has been dropped.");
-                }
-                if (dmgl is null)
-                {
-                    if (mstat.TryGetLocalPath() is string path)
-                    {
-                        dmgl = await StorageProvider.TryGetFileFromPathAsync(Path.ChangeExtension(path, "scan.dgml.xml"));
-                    }
-                }
-
                 viewModel.Loading = true;
-                using var mstaDataToCompare = await Task.Run(async () => Read(await mstat.OpenReadAsync(), dmgl is null ? null : await dmgl.OpenReadAsync()))
-                    .ContinueWith(t =>
-                    {
-                        viewModel.Loading = false;
-                        return t.Result;
-                    }, TaskScheduler.FromCurrentSynchronizationContext());
+
+                var (mstatStream, dmglStream) = await ReadStatFilesAsync(result);
+                var mstaDataToCompare = Read(mstatStream, dmglStream);
                 var view = new DiffView(currentData, mstaDataToCompare);
                 Utils.ShowWindow(view);
             }
@@ -157,6 +126,10 @@ public partial class MainView : UserControl
         catch (Exception ex)
         {
             await PromptErrorAsync(ex.Message);
+        }
+        finally
+        {
+            viewModel.Loading = false;
         }
     }
 
@@ -318,5 +291,45 @@ public partial class MainView : UserControl
                        """
         };
         await dialog.ShowAsync();
+    }
+    
+    private async Task<(MemoryStream mstatStream, MemoryStream? dmglStream)> ReadStatFilesAsync(IReadOnlyList<IStorageItem> result)
+    {
+        var mstat = result.FirstOrDefault(i => i is IStorageFile
+        {
+            Name: [.., '.', 'm' or 'M', 's' or 'S', 't' or 'T', 'a' or 'A', 't' or 'T']
+        }) as IStorageFile;
+        var dmgl = result.FirstOrDefault(i => i is IStorageFile
+        {
+            Name:
+            [
+                .., '.', 's' or 'S', 'c' or 'C', 'a' or 'A', 'n' or 'N', '.', 'd' or 'D', 'g' or 'G', 'm' or 'M',
+                'l' or 'L', '.', 'x' or 'X', 'm' or 'M', 'l' or 'L'
+            ]
+        }) as IStorageFile;
+        if (mstat is null)
+        {
+            throw new InvalidOperationException("An invalid file has been dropped.");
+        }
+
+        if (dmgl is null)
+        {
+            if (mstat.TryGetLocalPath() is string path)
+            {
+                dmgl = await StorageProvider.TryGetFileFromPathAsync(Path.ChangeExtension(path, "scan.dgml.xml"));
+            }
+        }
+
+        MemoryStream mstatStream = null, dmglStream = null;
+        await using var mstatFileStream = await mstat.OpenReadAsync();
+        await mstatFileStream.CopyToAsync(mstatStream = new MemoryStream());
+
+        if (dmgl is not null)
+        {
+            await using var dmglFileStream = await dmgl.OpenReadAsync();
+            await dmglFileStream.CopyToAsync(dmglStream = new MemoryStream());
+        }
+
+        return (mstatStream, dmglStream);
     }
 }

--- a/sizoscopeX/MainView.axaml.cs
+++ b/sizoscopeX/MainView.axaml.cs
@@ -32,32 +32,25 @@ public partial class MainView : UserControl
 
     private async void Drop(object? sender, DragEventArgs e)
     {
-        var currentFile = viewModel.File;
         try
         {
             e.DragEffects &= DragDropEffects.Copy;
             if (e.Data.Contains(DataFormats.Files))
             {
                 var files = e.Data.GetFiles()!.ToArray();
-                
+
                 var (mstatStream, dmglStream) = await ReadStatFilesAsync(files);
-                viewModel.File = (mstatStream, dmglStream);
+                await viewModel.LoadDataAsync(mstatStream, dmglStream);
             }
         }
         catch (Exception ex)
         {
             await PromptErrorAsync(ex.Message);
-            await Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                viewModel.File = currentFile;
-                viewModel.Loading = false;
-            });
         }
     }
 
     public async void Open_Clicked(object? sender, RoutedEventArgs args)
     {
-        var currentFile = viewModel.File;
         try
         {
             var result = await StorageProvider.OpenFilePickerAsync(new()
@@ -70,17 +63,12 @@ public partial class MainView : UserControl
             {
                 var (mstatStream, dmglStream) = await ReadStatFilesAsync(result);
 
-                viewModel.File = (mstatStream, dmglStream);
+                await viewModel.LoadDataAsync(mstatStream, dmglStream);
             }
         }
         catch (Exception ex)
         {
             await PromptErrorAsync(ex.Message);
-            await Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                viewModel.File = currentFile;
-                viewModel.Loading = false;
-            });
         }
     }
 

--- a/sizoscopeX/MstatData.cs
+++ b/sizoscopeX/MstatData.cs
@@ -61,7 +61,7 @@ public partial class MstatData : IDisposable
             Marshal.FreeHGlobal(_peImage);
     }
 
-    public static unsafe MstatData Read(Stream mstat, Stream? dgml)
+    public static unsafe MstatData Read(MemoryStream mstat, MemoryStream? dgml)
     {
         mstat.Seek(0, SeekOrigin.Begin);
         int length = checked((int)mstat.Length);

--- a/sizoscopeX/Utils.cs
+++ b/sizoscopeX/Utils.cs
@@ -1,9 +1,10 @@
 ﻿using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using FluentAvalonia.UI.Controls;
 
 namespace sizoscopeX;
 
-class Utils
+static class Utils
 {
     public static void ShowWindow(object? content)
     {
@@ -16,5 +17,23 @@ class Utils
                 frame.Content = content;
                 break;
         }
+    }
+
+    public static Task<T> TaskRunIfPossible<T>(Func<T> action)
+    {
+        if (OperatingSystem.IsBrowser())
+        {
+            return Task.FromResult(action());
+        }
+        else
+        {
+            return Task.Run(action);
+        }
+    }
+
+    public static async Task ContinueOnMainThread<T>(this Task<T> task, Action<T> continuation)
+    {
+        var result1 = await task;
+        await Dispatcher.UIThread.InvokeAsync(() => continuation(result1));
     }
 }

--- a/sizoscopeX/ViewModels/DiffViewModel.cs
+++ b/sizoscopeX/ViewModels/DiffViewModel.cs
@@ -16,10 +16,10 @@ public sealed class DiffViewModel : INotifyPropertyChanged
         var compareTree = new ObservableCollection<TreeNode>();
         Loading = true;
         TitleString = "Diff View - sizoscopeX";
-        Task.Run(() => Task.FromResult(MstatData.Diff(baseline, compare)))
-            .ContinueWith(t =>
+        _ = Utils.TaskRunIfPossible(() => MstatData.Diff(baseline, compare))
+            .ContinueOnMainThread(t =>
             {
-                (_baseline, _compare) = t.Result;
+                (_baseline, _compare) = t;
                 _diffSize = compare.Size - baseline.Size;
                 BaselineData = _baseline;
                 CompareData = _compare;
@@ -34,7 +34,7 @@ public sealed class DiffViewModel : INotifyPropertyChanged
                 TitleString = $"Diff View - Total accounted difference: {AsFileSize(_diffSize)} - sizoscopeX";
                 TitleChangedEvent?.Invoke(this, new());
                 Loading = false;
-            }, TaskScheduler.FromCurrentSynchronizationContext());
+            });
     }
 
     private int _baselineSortMode, _compareSortMode;

--- a/sizoscopeX/ViewModels/MainViewModel.cs
+++ b/sizoscopeX/ViewModels/MainViewModel.cs
@@ -18,7 +18,7 @@ public class MainViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private MstatData? _data;
-    private (Stream Mstat, Stream? Dgml)? _file;
+    private (MemoryStream Mstat, MemoryStream? Dgml)? _file;
     private int _sortMode;
     private int _searchMode;
     private string? _searchPattern;
@@ -52,7 +52,7 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MstatData? CurrentData => _data;
 
-    public (Stream Mstat, Stream? Dgml)? File
+    public (MemoryStream Mstat, MemoryStream? Dgml)? File
     {
         get => _file;
         set

--- a/sizoscopeX/ViewModels/MainViewModel.cs
+++ b/sizoscopeX/ViewModels/MainViewModel.cs
@@ -18,7 +18,6 @@ public class MainViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private MstatData? _data;
-    private (MemoryStream Mstat, MemoryStream? Dgml)? _file;
     private int _sortMode;
     private int _searchMode;
     private string? _searchPattern;
@@ -51,39 +50,6 @@ public class MainViewModel : INotifyPropertyChanged
     }
 
     public MstatData? CurrentData => _data;
-
-    public (MemoryStream Mstat, MemoryStream? Dgml)? File
-    {
-        get => _file;
-        set
-        {
-            if (value != _file)
-            {
-                _file?.Mstat?.Dispose();
-                _file?.Dgml?.Dispose();
-                _file = value;
-                PropertyChanged?.Invoke(this, new(nameof(File)));
-                _data?.Dispose();
-                if (value is null)
-                {
-                    _data = null;
-                    Items.Clear();
-                    SearchResult.Clear();
-                    return;
-                }
-                Loading = true;
-                _ = Utils.TaskRunIfPossible(() => Read(value.Value.Mstat, value.Value.Dgml))
-                    .ContinueOnMainThread(t =>
-                    {
-                        _data = t;
-                        PropertyChanged?.Invoke(this, new(nameof(DataFileSize)));
-                        RefreshTree(Items, _data, Sorter);
-                        RefreshSearch();
-                        Loading = false;
-                    });
-            }
-        }
-    }
 
     public int SortMode
     {
@@ -134,6 +100,37 @@ public class MainViewModel : INotifyPropertyChanged
 
     public string? DataFileSize => AsFileSize(CurrentData?.Size ?? 0);
 
+    public void ClearData()
+    {
+        _data?.Dispose();
+        _data = null;
+        Items.Clear();
+        SearchResult.Clear();
+    }
+    
+    public async Task LoadDataAsync(MemoryStream Mstat, MemoryStream? Dgml)
+    {
+        Loading = true;
+        try
+        {
+            var newData = await Utils.TaskRunIfPossible(() => Read(Mstat, Dgml));
+            
+            _data?.Dispose();
+            _data = newData;
+            Items.Clear();
+            SearchResult.Clear();
+            
+            PropertyChanged?.Invoke(this, new(nameof(DataFileSize)));
+            PropertyChanged?.Invoke(this, new(nameof(CurrentData)));
+            RefreshTree(Items, _data, Sorter);
+            RefreshSearch();
+        }
+        finally
+        {
+            Loading = false;
+        }
+    }
+    
     private void ExecuteSearch(object? sender, EventArgs args)
     {
         _searchDebouncer.Stop();

--- a/sizoscopeX/ViewModels/MainViewModel.cs
+++ b/sizoscopeX/ViewModels/MainViewModel.cs
@@ -72,15 +72,15 @@ public class MainViewModel : INotifyPropertyChanged
                     return;
                 }
                 Loading = true;
-                Task.Run(() => Task.FromResult(Read(value.Value.Mstat, value.Value.Dgml)))
-                    .ContinueWith(t =>
+                _ = Utils.TaskRunIfPossible(() => Read(value.Value.Mstat, value.Value.Dgml))
+                    .ContinueOnMainThread(t =>
                     {
-                        _data = t.Result;
+                        _data = t;
                         PropertyChanged?.Invoke(this, new(nameof(DataFileSize)));
                         RefreshTree(Items, _data, Sorter);
                         RefreshSearch();
                         Loading = false;
-                    }, TaskScheduler.FromCurrentSynchronizationContext());
+                    });
             }
         }
     }


### PR DESCRIPTION
Major changes in this PR:
1. Avoid Task.Run on browser by adding TaskRunIfPossible method
2. Avoid sync context issues on browser by adding ContinueOnMainThread method
3. Use only async method with non-in-memory streams manipulation. In-memory streams are safe, so I changed the type in some methods to ensure it.
4. Changed view model a bit to not keep original streams that were used from file parsing. It essentially halves down used RAM  usage (after GC).


Problems:
I noticed that this app eats tons of RAM while parsing optional XML file, and still keeps a lot after (way less after this PR, but still). Because of this, I am getting Out of memory error when opening dgml.xml files on Browser. Not sure what can be done there. Browser limit is essentially 4GB per tab, but could be way less inside of Mono virtual machine.
![image](https://github.com/hez2010/sizoscopeX/assets/3163374/d1a1ae7f-ee36-4a7c-9013-3bca43051922)
